### PR TITLE
feat: Add initial support for Grok API

### DIFF
--- a/index.html
+++ b/index.html
@@ -14,6 +14,7 @@
       <option value="openai">OpenAI</option>
       <option value="gemini">Gemini</option>
       <option value="claude">Claude</option>
+      <option value="grok">Grok</option>
     </select>
     <input id="api-key" type="password" placeholder="API Key" />
   </div>
@@ -26,6 +27,7 @@
           <option value="openai">OpenAI</option>
           <option value="gemini">Gemini</option>
           <option value="claude">Claude</option>
+          <option value="grok">Grok</option>
         </select>
         <select id="conversation-select"></select>
         <button id="new-chat-button">New Chat</button>


### PR DESCRIPTION
This commit introduces backend support for the Grok (xAI) provider.

Key changes:
- Modified `server.js` to add a new 'grok' provider option.
- Implemented the `/api/models` endpoint for Grok, currently returning a static placeholder model ID 'grok-1-placeholder'.
- Implemented the `/api/chat/completions` endpoint for Grok. This involves:
    - Proxying requests to an assumed Grok API endpoint (`https://api.x.ai/v1/chat/completions`).
    - Transforming incoming OpenAI-formatted requests to an assumed Grok request format.
    - Transforming outgoing Grok responses back to the OpenAI format.
    - Saving Grok responses to the `responses/` directory.
- Implemented a similar `/api/completions` endpoint for Grok, based on an assumed text completion API structure.
- Updated `index.html` to include "Grok" in the provider selection dropdowns, making it selectable in the user interface.

Note: The Grok API integration (endpoints, request/response formats) is based on common API patterns due to the lack of specific documentation at the time of implementation. These parts may need adjustment when official Grok API details are available.