### PR TITLE
Add DeepSeek LLM provider support

### DIFF
--- a/script.js
+++ b/script.js
@@ -97,6 +97,18 @@ document.addEventListener('DOMContentLoaded', () => {
   const logoutButton = document.getElementById('logout-button');
   const modelSelect = document.getElementById('model');
   const responseDiv = document.getElementById('response');
+
+  // Add DeepSeek option to provider select elements
+  const deepSeekOptionLogin = document.createElement('option');
+  deepSeekOptionLogin.value = 'deepseek';
+  deepSeekOptionLogin.textContent = 'DeepSeek';
+  loginProviderSelect.appendChild(deepSeekOptionLogin);
+
+  const deepSeekOptionHeader = document.createElement('option');
+  deepSeekOptionHeader.value = 'deepseek';
+  deepSeekOptionHeader.textContent = 'DeepSeek';
+  headerProviderSelect.appendChild(deepSeekOptionHeader);
+
   // Initialize UI based on stored provider and its API key
   const savedProvider = localStorage.getItem('provider') || 'openai';
   loginProviderSelect.value = savedProvider;


### PR DESCRIPTION
This commit introduces support for DeepSeek as an LLM provider.

Key changes:
- Modified script.js to include "DeepSeek" in the provider selection UI.
- Updated server.js to handle API requests for DeepSeek:
    - Added logic to fetch and list available DeepSeek models from https://api.deepseek.com/v1/models.
    - Added logic to proxy chat completion requests to https://api.deepseek.com/v1/chat/completions, transforming request and response payloads to be compatible with the existing UI.
    - Added logic to proxy legacy completion requests to https://api.deepseek.com/v1/completions, with similar payload transformations.
    - Ensured that responses from DeepSeek are saved to the /responses directory, consistent with other providers.

These changes allow you to select DeepSeek, input your API key, and utilize DeepSeek models for chat and completion tasks through the application.